### PR TITLE
Add error and breakpoint listeners

### DIFF
--- a/src/VisualStudioCode/Extension/README.md
+++ b/src/VisualStudioCode/Extension/README.md
@@ -1,10 +1,19 @@
 # Code Talk
 
-Code Talk for Visual Studio Code helps make software development more inclusive by enabled the following accessibility features.
+Code Talk is a step towards making programming IDEs more accessible. The extension currently concentrates on three main aspects of Programming:
 
-* Function List viewer
-
+1. Glanceability
+2. Real-Time Error information
+3. Accessible Debugging
 
 ## Function List Viewer
 
 <img src="https://user-images.githubusercontent.com/599935/119587186-00fedc00-bd83-11eb-97cb-f3c992ba09f7.png" alt="demo" style="width:640px;"/>
+
+## Talk Points
+
+<img src="https://user-images.githubusercontent.com/599935/119595275-26dfad00-bd92-11eb-98ed-e13c77b2d861.png" alt="demo" style="width:460px;"/>
+
+## Talk Diagnostics
+
+<img src="https://user-images.githubusercontent.com/599935/119595285-2b0bca80-bd92-11eb-86aa-1ee81d4a6178.png" alt="demo" style="width:400px;"/>

--- a/src/VisualStudioCode/LanguageService/CodeTalk.LanguageService/ServiceHost.cs
+++ b/src/VisualStudioCode/LanguageService/CodeTalk.LanguageService/ServiceHost.cs
@@ -166,19 +166,19 @@ namespace CodeTalk.LanguageService
                     Capabilities = new ServerCapabilities
                     {
                         TextDocumentSync = TextDocumentSyncKind.Incremental,
-                        DefinitionProvider = true,
+                        DefinitionProvider = false,
                         ReferencesProvider = false,
-                        DocumentFormattingProvider = true,
-                        DocumentRangeFormattingProvider = true,
+                        DocumentFormattingProvider = false,
+                        DocumentRangeFormattingProvider = false,
                         DocumentHighlightProvider = false,
-                        HoverProvider = true,
+                        HoverProvider = false,
                         CompletionProvider = new CompletionOptions
                         {
-                            ResolveProvider = true,
+                            ResolveProvider = false,
                             TriggerCharacters = CompletionTriggerCharacters
                         },
                         SignatureHelpProvider = new SignatureHelpOptions
-                        {
+                        {                        
                             TriggerCharacters = new string[] { " ", "," }
                         }
                     }


### PR DESCRIPTION
This change adds listeners for new syntax errors and debugger breakpoint events.  The extension is currently showing a pop-up notification on these events, but the plan is to change this to alert sounds.

Screenshot of notification on breakpoint.
![image](https://user-images.githubusercontent.com/599935/119595275-26dfad00-bd92-11eb-98ed-e13c77b2d861.png)

Screenshot of notification on new syntax error.
![image](https://user-images.githubusercontent.com/599935/119595285-2b0bca80-bd92-11eb-86aa-1ee81d4a6178.png)
